### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through a stack trace

### DIFF
--- a/src/inspector-util.ts
+++ b/src/inspector-util.ts
@@ -415,8 +415,8 @@ export async function startProfilerServer(httpServerPort?: number | string): Pro
     try {
       profilerResults = stopProfiler();
     } catch (error: any) {
-      console.error(error);
-      res.status(500).end(error);
+      logger.error("Exception occurred", error);
+      res.status(500).end("An internal server error occurred");
       return;
     }
     const fileName = `profile-${Date.now()}.svg`;


### PR DESCRIPTION
Potential fix for [https://github.com/slowedcodinganai/stacks-blockchain-api/security/code-scanning/5](https://github.com/slowedcodinganai/stacks-blockchain-api/security/code-scanning/5)

To fix the problem, we need to ensure that the stack trace or any sensitive information contained in the error object is not sent to the client. Instead, we should log the error on the server and send a generic error message to the client. This can be achieved by modifying the catch blocks to log the error and send a generic message.

1. Modify the catch block on line 417 to log the error and send a generic error message.
2. Ensure that the error logging mechanism is in place (e.g., using the `logger` module).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
